### PR TITLE
PDF生成のChromeインストールをnpx非依存にしてRelease失敗を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "setup": "npx puppeteer browsers install chrome",
+    "setup": "puppeteer browsers install chrome",
     "lint": "textlint docs/README.md && markdownlint docs/README.md",
     "build:pdf": "node pdf/generate.js"
   },


### PR DESCRIPTION
## 概要

`Release PDF` ワークフローの `Generate PDF from Jekyll HTML` ステップが `Error: Could not find Chrome (ver. 132.0.6834.110)` で失敗し、タグだけ作成されてReleaseが公開されない問題を修正。

## 原因

- `setup` スクリプトが `npx puppeteer browsers install chrome` という **`npx` 任せ**の形だった
- `npx` のパッケージ解決・キャッシュ挙動は非決定的で、CIランナー上では **ローカルの puppeteer bin を使わず、何も出力せず即終了**（Chromeをインストールしない）
- 結果、後続の `build:pdf`（puppeteer-coreがChrome 132を要求）がChromeを見つけられず失敗
- `.npmrc` の `ignore-scripts=true`（サプライチェーン対策）により puppeteer の postinstall 自動DLが無効なため、`setup` の確実な動作が前提になっている

### 切り分け

| | setup の挙動 |
|---|---|
| #93（4/22・成功） | Chrome 132 を71MB DL |
| #103（今回・失敗） | 1.7秒・出力ゼロで終了（Chrome未DL） |

package.json / lock / workflow は両者で変化なし。`npx` の非決定性が再発要因。

## 修正

```diff
-    "setup": "npx puppeteer browsers install chrome",
+    "setup": "puppeteer browsers install chrome",
```

`npm run setup` 経由なら `node_modules/.bin` がPATHに入るため、ローカルの puppeteer bin が確実に呼ばれる。

## ローカル検証（`ignore-scripts=true`・`npm ci` 後・Chromeキャッシュ削除済み）

- `npm run setup`: `chrome@132.0.6834.110 ...` を正常DL（EXIT=0）
- `node pdf/generate.js`: Chrome起動・`page.goto` まで到達（`_site` 未ビルドのため `ERR_FILE_NOT_FOUND` で停止 ＝ 元の「Chrome不在」エラーは解消。CIでは直前のJekyllビルドでHTMLが存在するため完走見込み）

## 備考

- mainマージ後、`docs/README.md` 変更を含むpushで次タグ採番＋正常なRelease生成を確認予定
- 先行のrun #103 で作成済みの中途タグ `v1.1.12`（PDF未添付・Releaseなし）は残存。次回正常リリース（`v1.1.13`）で実質上書きされる