### PR TITLE
Release PDFのChromeインストールを確実化しworkflow_dispatch追加

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - docs/README.md
+  workflow_dispatch:
 
 jobs:
   release:
@@ -14,6 +15,8 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
+    env:
+      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
     steps:
       - uses: actions/checkout@v6
         with:
@@ -43,7 +46,17 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - run: npm run setup
+      - name: Install Chrome for Puppeteer
+        run: |
+          set -x
+          # npx ではなく node_modules のローカル puppeteer CLI を直接実行する
+          # （npx 経由だと CI 上で何も DL せず無言終了することがあるため）
+          node node_modules/puppeteer/lib/cjs/puppeteer/node/cli.js browsers install chrome
+          # Chrome が実際に配置されたか検証し、無ければ即 fail させる
+          # （install が無言で何もしなくても後続まで通過させない）
+          CHROME_BIN=$(find "$PUPPETEER_CACHE_DIR/chrome" -name chrome -type f | head -1)
+          echo "Resolved Chrome: ${CHROME_BIN:-<none>}"
+          test -n "$CHROME_BIN" && test -f "$CHROME_BIN"
       - name: Generate PDF from Jekyll HTML
         run: npm run build:pdf
       - name: Rename PDF


### PR DESCRIPTION
## 概要

#108 の修正後も `Release PDF` の `Generate PDF` が `Could not find Chrome (ver. 132.0.6834.110)` で失敗していた（run 26714428476）。`setup`（`puppeteer browsers install chrome`）が CI 上で無言で Chrome を DL しないことがあり、後続の `build:pdf` が Chrome を見つけられなかった。

## 修正

1. **`PUPPETEER_CACHE_DIR` を workspace 内に固定**（job env）
   - install 先と `puppeteer.launch` の探索先を一致させ、cache パスの不整合を構造的に排除
2. **Chrome インストールを堅牢化**（`npm run setup` を置換）
   - ローカル puppeteer CLI を直接実行（`browsers install chrome`）
   - インストール後に Chrome バイナリの存在を `test -f` で**検証**し、無言で失敗した場合はそのステップで**即 fail**（後続まで通過させない）
3. **`workflow_dispatch` を追加**
   - `docs/README.md` 変更なしに手動再実行可能にし、再発時の CI デバッグを容易化

## 検証（`PUPPETEER_CACHE_DIR` を workspace 固定した CI 同等条件）

- `browsers install chrome`: Chrome 132 を正常DL
- 存在検証: `VERIFY OK`
- `build:pdf`: **PDF生成成功**（ダミーHTMLで Chrome 起動・PDF出力を確認）

## マージ後の手順

1. マージ後、Actions から **手動で `Release PDF` を実行**（workflow_dispatch）
2. PDF生成・Release公開を確認

## 備考

- 調査中、CIでの無言失敗のローカル完全再現には至らなかったが、`PUPPETEER_CACHE_DIR` 固定＋存在検証により「Chromeが無いまま後続に進む」経路を塞いだ。万一それでも DL されない場合は検証ステップが `Resolved Chrome: <none>` を出して即 fail するため、原因がログで特定できる
- 先行の中途タグ `v1.1.12` / `v1.1.13`（PDF未添付）が残存。本修正後の手動実行で正常な Release を生成