### PR TITLE
PDF生成をGitHub提供のChromeに切り替え

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,8 +15,6 @@ jobs:
     timeout-minutes: 10
     permissions:
       contents: write
-    env:
-      PUPPETEER_CACHE_DIR: ${{ github.workspace }}/.cache/puppeteer
     steps:
       - uses: actions/checkout@v6
         with:
@@ -46,18 +44,18 @@ jobs:
           node-version: 24
           cache: npm
       - run: npm ci
-      - name: Install Chrome for Puppeteer
+      # puppeteer による Chrome の自前DLは CI 上で無言失敗するため、
+      # GitHub Actions 提供の Chrome をインストールして使う
+      - name: Setup Chrome
+        id: setup-chrome
+        uses: browser-actions/setup-chrome@v2
+      - name: Verify Chrome
         run: |
-          set -x
-          # npx ではなく node_modules のローカル puppeteer CLI を直接実行する
-          # （npx 経由だと CI 上で何も DL せず無言終了することがあるため）
-          node node_modules/puppeteer/lib/cjs/puppeteer/node/cli.js browsers install chrome
-          # Chrome が実際に配置されたか検証し、無ければ即 fail させる
-          # （install が無言で何もしなくても後続まで通過させない）
-          CHROME_BIN=$(find "$PUPPETEER_CACHE_DIR/chrome" -name chrome -type f | head -1)
-          echo "Resolved Chrome: ${CHROME_BIN:-<none>}"
-          test -n "$CHROME_BIN" && test -f "$CHROME_BIN"
+          echo "Chrome path: ${{ steps.setup-chrome.outputs.chrome-path }}"
+          test -x "${{ steps.setup-chrome.outputs.chrome-path }}"
       - name: Generate PDF from Jekyll HTML
+        env:
+          PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}
         run: npm run build:pdf
       - name: Rename PDF
         run: mv docs/README.pdf "docs/resume_${{ steps.version.outputs.name }}.pdf"

--- a/pdf/generate.js
+++ b/pdf/generate.js
@@ -6,6 +6,8 @@ const path = require("path");
   const outputPath = path.resolve(__dirname, "../docs/README.pdf");
 
   const browser = await puppeteer.launch({
+    // PUPPETEER_EXECUTABLE_PATH があればそれを使う（CIではGitHub提供のChromeを指定）
+    executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined,
     args: ["--no-sandbox", "--disable-setuid-sandbox"],
   });
   const page = await browser.newPage();


### PR DESCRIPTION
## 概要

`Release PDF` の `Generate PDF` が `Could not find Chrome (ver. 132.0.6834.110)` で失敗し続けていた問題を根本解決する。

#108（npx非依存化）・#110（PUPPETEER_CACHE_DIR固定＋存在検証）でも解消せず、#110の検証ステップにより**`puppeteer browsers install chrome` がCI上で無言（1.16秒・出力ゼロ）でChromeをDLしていない**ことが判明（`Resolved Chrome: <none>` で即fail）。ローカルでは毎回成功するためCI固有で再現困難だった。

## 修正

puppeteerの自前DLに依存せず、**GitHub Actions提供のChromeを使う**:

- `release.yaml`:
  - `Install Chrome for Puppeteer`（puppeteer DL）を `browser-actions/setup-chrome@v2` + `Verify Chrome` に置換
  - `Generate PDF` に `PUPPETEER_EXECUTABLE_PATH: ${{ steps.setup-chrome.outputs.chrome-path }}` を設定
  - 不要になった `PUPPETEER_CACHE_DIR` env を削除
- `pdf/generate.js`:
  - `puppeteer.launch` に `executablePath: process.env.PUPPETEER_EXECUTABLE_PATH || undefined` を追加（環境変数があればそのChromeを使用、なければ従来通り）

## 検証（ローカル・システムChromeを指定）

- `PUPPETEER_EXECUTABLE_PATH=/snap/bin/chromium npm run build:pdf` → **PDF生成成功**

setup-chrome の output名 `chrome-path` は公式READMEで確認済み。

## マージ後

- `workflow_dispatch`（#110で追加済み）で手動実行し、PDF生成・Release公開を確認
- 中途タグ `v1.1.12`〜（PDF未添付）が残存。正常実行で次タグのReleaseを生成